### PR TITLE
[downloads] Don't use `Worker` to highlight the code

### DIFF
--- a/assets/download.js
+++ b/assets/download.js
@@ -530,7 +530,7 @@
 					newCode.className = codeElement.className;
 					newCode.textContent = text;
 
-					Prism.highlightElement(newCode, true, function () {
+					Prism.highlightElement(newCode, false, function () {
 						pre.replaceChild(newCode, codeElement);
 					});
 


### PR DESCRIPTION
To avoid the “SecurityError: Failed to construct 'Worker': Script at ... cannot be accessed from origin ...” error