### PR TITLE
Add TypeDoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ Thumbs.db
 
 # Generated files
 *.html
+api
 
 # Cache
 .cache

--- a/_build/eleventy.js
+++ b/_build/eleventy.js
@@ -4,7 +4,7 @@ import markdownItDeflist from "markdown-it-deflist";
 import pluginTOC from "eleventy-plugin-toc";
 import * as filters from "./filters.js";
 
-import components from "prismjs/components.json" with { type: "json" };
+import components from "prismjs/src/components.json" with { type: "json" };
 
 export default config => {
 	let data = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,9 @@
 				"prettier-plugin-brace-style": "^0.7.2",
 				"prettier-plugin-merge": "^0.7.2",
 				"prettier-plugin-space-before-function-paren": "^0.0.7",
-				"prismjs": "github:PrismJS/prism"
+				"prismjs": "github:PrismJS/prism#v2",
+				"typedoc": "^0.28.1",
+				"typedoc-plugin-rename-defaults": "^0.7.3"
 			}
 		},
 		"node_modules/@11ty/dependency-tree": {
@@ -252,6 +254,18 @@
 				"slash": "^1.0.0"
 			}
 		},
+		"node_modules/@gerrit0/mini-shiki": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.2.1.tgz",
+			"integrity": "sha512-HbzRC6MKB6U8kQhczz0APKPIzFHTrcqhaC7es2EXInq1SpjPVnpVSIsBe6hNoLWqqCx1n5VKiPXq6PfXnHZKOQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/engine-oniguruma": "^3.2.1",
+				"@shikijs/types": "^3.2.1",
+				"@shikijs/vscode-textmate": "^10.0.2"
+			}
+		},
 		"node_modules/@isaacs/cliui": {
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -339,6 +353,35 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/@shikijs/engine-oniguruma": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.2.1.tgz",
+			"integrity": "sha512-wZZAkayEn6qu2+YjenEoFqj0OyQI64EWsNR6/71d1EkG4sxEOFooowKivsWPpaWNBu3sxAG+zPz5kzBL/SsreQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "3.2.1",
+				"@shikijs/vscode-textmate": "^10.0.2"
+			}
+		},
+		"node_modules/@shikijs/types": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.2.1.tgz",
+			"integrity": "sha512-/NTWAk4KE2M8uac0RhOsIhYQf4pdU0OywQuYDGIGAJ6Mjunxl2cGiuLkvu4HLCMn+OTTLRWkjZITp+aYJv60yA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.4"
+			}
+		},
+		"node_modules/@shikijs/vscode-textmate": {
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+			"integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@sindresorhus/slugify": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-2.2.1.tgz",
@@ -372,6 +415,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/@types/hast": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+			"integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "*"
+			}
+		},
 		"node_modules/@types/linkify-it": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
@@ -399,6 +452,13 @@
 			"dev": true,
 			"license": "MIT",
 			"peer": true
+		},
+		"node_modules/@types/unist": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/a-sync-waterfall": {
 			"version": "1.0.1",
@@ -678,6 +738,19 @@
 			"dependencies": {
 				"hookified": "^1.7.1",
 				"keyv": "^5.3.1"
+			}
+		},
+		"node_modules/camelcase": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+			"integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/chardet": {
@@ -1943,6 +2016,13 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/lunr": {
+			"version": "2.3.9",
+			"resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+			"integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/luxon": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
@@ -2564,12 +2644,12 @@
 			}
 		},
 		"node_modules/prismjs": {
-			"version": "1.30.0",
-			"resolved": "git+ssh://git@github.com/PrismJS/prism.git#76dde18a575831c91491895193f56081ac08b0c5",
+			"version": "1.29.0",
+			"resolved": "git+ssh://git@github.com/PrismJS/prism.git#f5343b82f95bb4f5e02b83581d64180216458a88",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=6"
+				"node": ">=14"
 			}
 		},
 		"node_modules/promise": {
@@ -2989,6 +3069,84 @@
 				"node": ">=0.6"
 			}
 		},
+		"node_modules/typedoc": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.1.tgz",
+			"integrity": "sha512-Mn2VPNMaxoe/hlBiLriG4U55oyAa3Xo+8HbtEwV7F5WEOPXqtxzGuMZhJYHaqFJpajeQ6ZDUC2c990NAtTbdgw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@gerrit0/mini-shiki": "^3.2.1",
+				"lunr": "^2.3.9",
+				"markdown-it": "^14.1.0",
+				"minimatch": "^9.0.5",
+				"yaml": "^2.7.0 "
+			},
+			"bin": {
+				"typedoc": "bin/typedoc"
+			},
+			"engines": {
+				"node": ">= 18",
+				"pnpm": ">= 10"
+			},
+			"peerDependencies": {
+				"typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x"
+			}
+		},
+		"node_modules/typedoc-plugin-rename-defaults": {
+			"version": "0.7.3",
+			"resolved": "https://registry.npmjs.org/typedoc-plugin-rename-defaults/-/typedoc-plugin-rename-defaults-0.7.3.tgz",
+			"integrity": "sha512-fDtrWZ9NcDfdGdlL865GW7uIGQXlthPscURPOhDkKUe4DBQSRRFUf33fhWw41FLlsz8ZTeSxzvvuNmh54MynFA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"camelcase": "^8.0.0"
+			},
+			"peerDependencies": {
+				"typedoc": ">=0.22.x <0.29.x"
+			}
+		},
+		"node_modules/typedoc/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/typedoc/node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "5.8.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+			"integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
 		"node_modules/uc.micro": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
@@ -3180,6 +3338,19 @@
 				"utf-8-validate": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/yaml": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+			"integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
 	"description": "The website of prismjs.com",
 	"type": "module",
 	"scripts": {
+		"dependencies": "npm install --prefix node_modules/prismjs",
 		"dev": "netlify dev -p 8844",
 		"serve": "npx @11ty/eleventy --config=_build/eleventy.js --serve --quiet",
 		"build:html": "npx @11ty/eleventy --config=_build/eleventy.js --quiet",
-		"build": "npm run build:html",
+		"build:apidocs": "npx typedoc",
+		"build": "npm run build:html && npm run build:apidocs",
 		"watch:html": "npx @11ty/eleventy --config=_build/eleventy.js --watch --quiet --incremental",
 		"watch": "npm run watch:html"
 	},
@@ -31,6 +33,8 @@
 		"prettier-plugin-brace-style": "^0.7.2",
 		"prettier-plugin-merge": "^0.7.2",
 		"prettier-plugin-space-before-function-paren": "^0.0.7",
-		"prismjs": "github:PrismJS/prism"
+		"prismjs": "github:PrismJS/prism#v2",
+		"typedoc": "^0.28.1",
+		"typedoc-plugin-rename-defaults": "^0.7.3"
 	}
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,31 @@
+{
+	"$schema": "https://typedoc.org/schema.json",
+	"out": "./api",
+	"json": "./api/docs.json",
+	"name": "Prism API",
+	"includeVersion": true,
+	"entryPoints": ["node_modules/prismjs/src/**/*.ts"],
+	"exclude": [
+		"node_modules/prismjs/src/plugins/**/*.ts",
+		"node_modules/prismjs/src/languages/**/*.ts",
+		"node_modules/prismjs/src/known-plugins.d.ts"
+	],
+	"externalPattern": ["**/node_modules/**/node_modules/**"],
+	"compilerOptions": {
+		"skipLibCheck": true,
+		"noCheck": true
+	},
+	"markdownItOptions": {
+		"html": true,
+		"linkify": true,
+		"typographer": true
+	},
+	"plugin": ["typedoc-plugin-rename-defaults"],
+	"navigationLinks": {
+		"Home": "https://prismjs.com",
+		"GitHub": "https://github.com/PrismJS/prism"
+	},
+	"favicon": "./assets/logo.svg",
+	"hostedBaseUrl": "https://prismjs.com/api",
+	"readme": "none"
+}


### PR DESCRIPTION
We'll probably tweak it along the way. We need something to start with. 🙂

For now, the following files and directories are excluded:
- `plugins/` — moved to `plugins.prismjs.com`
- `known-plugins.d.ts`
- `languages/` — will we switch back to JS? In API, they don't give any additional info (except the interface they conform to)

<img width="771" alt="image" src="https://github.com/user-attachments/assets/ea99f382-1993-4678-8bdd-7e0769d20110" />


Preview: https://deploy-preview-21--prismjs-website.netlify.app/api/