### PR TITLE
[build] Fix broken import

### DIFF
--- a/_build/eleventy.js
+++ b/_build/eleventy.js
@@ -4,7 +4,7 @@ import markdownItDeflist from "markdown-it-deflist";
 import pluginTOC from "eleventy-plugin-toc";
 import * as filters from "./filters.js";
 
-import components from "prismjs/src/components.json" with { type: "json" };
+import components from "../node_modules/prismjs/src/components.json" with { type: "json" };
 
 /** @param {import("@11ty/eleventy").UserConfig} config */
 export default config => {


### PR DESCRIPTION
Prism doesn't export `src/components.json` (after recent changes), so we need to import `components.json` directly from `node_modules`.